### PR TITLE
cmake: add no test pins to not generate PCF constraints in generic tests

### DIFF
--- a/common/cmake/devices.cmake
+++ b/common/cmake/devices.cmake
@@ -24,6 +24,7 @@ function(DEFINE_ARCH)
   #    RR_PATCH_CMD <command to run RR_PATCH_TOOL>
   #    DEVICE_FULL_TEMPLATE <template for constructing DEVICE_FULL strings.
   #    [NO_PINS]
+  #    [NO_TEST_PINS]
   #    [NO_PLACE]
   #    [NO_PLACE_CONSTR]
   #    [USE_FASM]
@@ -63,6 +64,8 @@ function(DEFINE_ARCH)
   #  * DOC_PRJ_DB - path to the third party documentation database
   #
   # If NO_PINS is set, PLACE_TOOL and PLACE_TOOL_CMD cannot be specified.
+  # If NO_TEST_PINS is set, the automatic generation of the constraints file for
+  # the generic tests is skipped.
   # If NO_BITSTREAM is set, HLC_TO_BIT, HLC_TO_BIT_CMD BIT_TO_V,
   # BIT_TO_V_CMD, BIT_TO_BIN and BIT_TO_BIN_CMD cannot be specified.
   #
@@ -132,6 +135,7 @@ function(DEFINE_ARCH)
   set(options
     NO_PLACE_CONSTR
     NO_PINS
+    NO_TEST_PINS
     NO_BITSTREAM
     NO_BIT_TO_BIN
     NO_BIT_TO_V
@@ -197,6 +201,7 @@ function(DEFINE_ARCH)
     RR_PATCH_CMD
     NO_PLACE_CONSTR
     NO_PINS
+    NO_TEST_PINS
     NO_BITSTREAM
     NO_BIT_TO_BIN
     NO_BIT_TO_V

--- a/quicklogic/common/cmake/quicklogic_qlf_arch.cmake
+++ b/quicklogic/common/cmake/quicklogic_qlf_arch.cmake
@@ -45,7 +45,7 @@ function(QUICKLOGIC_DEFINE_QLF_ARCH)
       \${PYTHON3} \${RR_PATCH_TOOL} \
           --rr-graph-in \${OUT_RRXML_VIRT} \
           --rr-graph-out \${OUT_RRXML_REAL}"
-  
+
     PLACE_TOOL
       ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/${FAMILY}/utils/create_ioplace.py
     PLACE_TOOL_CMD "${CMAKE_COMMAND} -E env \
@@ -57,6 +57,7 @@ function(QUICKLOGIC_DEFINE_QLF_ARCH)
           --net \${OUT_NET} \
           --csv_file \${PINMAP}"
 
+    NO_TEST_PINS
     NO_PLACE_CONSTR
 
     # With the current support there is no bitstream generation support yet.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,12 +55,13 @@ function(add_simple_test)
     get_target_property_required(DEVICE ${BOARD} DEVICE)
     get_target_property_required(ARCH ${DEVICE} ARCH)
     get_target_property_required(NO_PINS ${ARCH} NO_PINS)
+    get_target_property_required(NO_TEST_PINS ${ARCH} NO_TEST_PINS)
     get_target_property_required(NO_BITSTREAM ${ARCH} NO_BITSTREAM)
 
     set_target_properties(${BOARD} PROPERTIES PART "dummy")
 
     set(INPUT_IO_FILE_ARG "")
-    if(NOT ${NO_PINS})
+    if(NOT ${NO_PINS} AND NOT ${NO_TEST_PINS})
       generate_pinmap(
           NAME ${ADD_SIMPLE_TEST_NAME}_${BOARD}.pcf
         TOP top


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>